### PR TITLE
Fix URL-safe base64 state + add console logging for debugging

### DIFF
--- a/static/cms-oauth/callback.php
+++ b/static/cms-oauth/callback.php
@@ -76,7 +76,9 @@ function callbackUrl(): string
 function verifyState(string $state, string $secret): bool
 {
     if ($state === '') return false;
-    $decoded = base64_decode($state . str_repeat('=', strlen($state) % 4), strict: true);
+    // Reverse URL-safe base64 (-_ → +/) and restore padding before decoding
+    $b64     = strtr($state, '-_', '+/') . str_repeat('=', strlen($state) % 4);
+    $decoded = base64_decode($b64, strict: true);
     if ($decoded === false) return false;
     $parts = explode(':', $decoded, 3);
     if (count($parts) !== 3) return false;
@@ -114,16 +116,21 @@ function renderSuccess(string $token): void
     (function () {
       var payload = {$payload};
 
+      console.log('[OAuth] opener:', window.opener);
+
       if (!window.opener) {
         document.querySelector('p').textContent =
           'Fehler: window.opener ist null – Fenster schließen und erneut versuchen.';
         return;
       }
 
+      console.log('[OAuth] → authorizing:github');
       window.opener.postMessage('authorizing:github', '*');
 
       window.addEventListener('message', function handler(e) {
+        console.log('[OAuth] ← message from CMS:', e.data, 'origin:', e.origin);
         window.removeEventListener('message', handler);
+        console.log('[OAuth] → sending success token');
         window.opener.postMessage('authorization:github:success:' + payload, e.origin);
       }, false);
     })();

--- a/static/cms-oauth/index.php
+++ b/static/cms-oauth/index.php
@@ -80,5 +80,6 @@ function makeState(string $secret): string
     $ts    = (string) time();
     $nonce = bin2hex(random_bytes(12));
     $sig   = hash_hmac('sha256', $ts . ':' . $nonce, $secret);
-    return rtrim(base64_encode($ts . ':' . $nonce . ':' . $sig), '=');
+    // URL-safe base64: +/ → -_ so the value survives PHP query-string decoding
+    return rtrim(strtr(base64_encode($ts . ':' . $nonce . ':' . $sig), '+/', '-_'), '=');
 }


### PR DESCRIPTION
Standard base64 uses + and / which PHP decodes as space/slash from URL query strings, silently breaking HMAC state verification. Now uses URL-safe base64 (-_ instead of +/) in both makeState and verifyState so the state token survives the GitHub redirect round-trip.

Console logs added to callback.php success page to trace the postMessage flow in browser dev tools.

https://claude.ai/code/session_01NjQqELom2e3izg5ZPrthgZ