### PR TITLE
Send OAuth token directly — Decap CMS v3 skips the handshake

### DIFF
--- a/static/cms-oauth/callback.php
+++ b/static/cms-oauth/callback.php
@@ -124,15 +124,9 @@ function renderSuccess(string $token): void
         return;
       }
 
-      console.log('[OAuth] → authorizing:github');
-      window.opener.postMessage('authorizing:github', '*');
-
-      window.addEventListener('message', function handler(e) {
-        console.log('[OAuth] ← message from CMS:', e.data, 'origin:', e.origin);
-        window.removeEventListener('message', handler);
-        console.log('[OAuth] → sending success token');
-        window.opener.postMessage('authorization:github:success:' + payload, e.origin);
-      }, false);
+      // Decap CMS v3 does not reply to 'authorizing:github' — send the token directly.
+      console.log('[OAuth] → sending success token');
+      window.opener.postMessage('authorization:github:success:' + payload, '*');
     })();
     </script>
     </body>


### PR DESCRIPTION
Decap CMS v3 does not reply to 'authorizing:github', so the popup's message listener was waiting forever. Now sends the success token directly to window.opener with '*'.

https://claude.ai/code/session_01NjQqELom2e3izg5ZPrthgZ